### PR TITLE
Feat: 회원가입 로직 수정

### DIFF
--- a/src/main/java/prefolio/prefolioserver/controller/UserController.java
+++ b/src/main/java/prefolio/prefolioserver/controller/UserController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import prefolio.prefolioserver.domain.User;
 import prefolio.prefolioserver.dto.CommonResponseDTO;
@@ -15,6 +16,7 @@ import prefolio.prefolioserver.dto.request.JoinUserRequestDTO;
 import prefolio.prefolioserver.dto.response.GetUserInfoResponseDTO;
 import prefolio.prefolioserver.dto.response.CheckUserResponseDTO;
 import prefolio.prefolioserver.dto.response.JoinUserResponseDTO;
+import prefolio.prefolioserver.service.UserDetailsImpl;
 import prefolio.prefolioserver.service.UserService;
 
 
@@ -38,8 +40,11 @@ public class UserController {
     })
     @PostMapping("/join")
     @ResponseBody
-    public CommonResponseDTO<JoinUserResponseDTO> joinUser(@RequestBody JoinUserRequestDTO joinUserRequest) {
-        return CommonResponseDTO.onSuccess("유저 정보 저장 성공", userService.joinUser(joinUserRequest));
+    public CommonResponseDTO<JoinUserResponseDTO> joinUser(
+            @AuthenticationPrincipal UserDetailsImpl authUser,
+            @RequestBody JoinUserRequestDTO joinUserRequest
+    ) {
+        return CommonResponseDTO.onSuccess("유저 정보 저장 성공", userService.joinUser(authUser, joinUserRequest));
     }
 
     @Operation(summary = "유저 닉네임 중복", description = "유저 닉네임 중복 확인 메서드입니다.")

--- a/src/main/java/prefolio/prefolioserver/domain/User.java
+++ b/src/main/java/prefolio/prefolioserver/domain/User.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.Date;
 
@@ -12,6 +13,7 @@ import java.util.Date;
 @Entity
 @Table(name = "User")
 @NoArgsConstructor
+@Setter
 public class User {
 
     @Id

--- a/src/main/java/prefolio/prefolioserver/dto/request/JoinUserRequestDTO.java
+++ b/src/main/java/prefolio/prefolioserver/dto/request/JoinUserRequestDTO.java
@@ -20,7 +20,6 @@ public class JoinUserRequestDTO {
 
         private Integer grade;
 
-        private String refreshToken;
 
         /* Dto -> Entity */
         public JoinUserRequestDTO (User user) {
@@ -28,6 +27,5 @@ public class JoinUserRequestDTO {
             this.nickname = user.getNickname();
             this.profileImage = user.getProfileImage();
             this.grade = user.getGrade();
-            this.refreshToken = user.getRefreshToken();
         }
 }

--- a/src/main/java/prefolio/prefolioserver/service/KakaoServiceImpl.java
+++ b/src/main/java/prefolio/prefolioserver/service/KakaoServiceImpl.java
@@ -23,7 +23,7 @@ import org.springframework.web.client.RestTemplate;
 import prefolio.prefolioserver.domain.User;
 import prefolio.prefolioserver.dto.response.KakaoLoginResponseDTO;
 import prefolio.prefolioserver.dto.KakaoUserInfoDTO;
-import prefolio.prefolioserver.repository.UserRepository;
+import prefolio.prefolioserver.service.repository.UserRepository;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;

--- a/src/main/java/prefolio/prefolioserver/service/PostServiceImpl.java
+++ b/src/main/java/prefolio/prefolioserver/service/PostServiceImpl.java
@@ -3,15 +3,12 @@ package prefolio.prefolioserver.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import prefolio.prefolioserver.domain.*;
-import prefolio.prefolioserver.dto.*;
 import prefolio.prefolioserver.dto.request.AddPostRequestDTO;
 import prefolio.prefolioserver.dto.response.AddPostResponseDTO;
-import prefolio.prefolioserver.dto.response.ClickLikeResponseDTO;
-import prefolio.prefolioserver.dto.response.ClickScrapResponseDTO;
 import prefolio.prefolioserver.dto.response.GetPostResponseDTO;
-import prefolio.prefolioserver.repository.LikeRepository;
-import prefolio.prefolioserver.repository.PostRepository;
-import prefolio.prefolioserver.repository.ScrapRepository;
+import prefolio.prefolioserver.service.repository.LikeRepository;
+import prefolio.prefolioserver.service.repository.PostRepository;
+import prefolio.prefolioserver.service.repository.ScrapRepository;
 
 import java.util.Optional;
 

--- a/src/main/java/prefolio/prefolioserver/service/UserDetailsServiceImpl.java
+++ b/src/main/java/prefolio/prefolioserver/service/UserDetailsServiceImpl.java
@@ -6,7 +6,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import prefolio.prefolioserver.domain.User;
-import prefolio.prefolioserver.repository.UserRepository;
+import prefolio.prefolioserver.service.repository.UserRepository;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/prefolio/prefolioserver/service/UserService.java
+++ b/src/main/java/prefolio/prefolioserver/service/UserService.java
@@ -15,7 +15,7 @@ public interface UserService {
 
 
     @Transactional
-    JoinUserResponseDTO joinUser(JoinUserRequestDTO joinUserRequest);
+    JoinUserResponseDTO joinUser(UserDetailsImpl authUser, JoinUserRequestDTO joinUserRequest);
 
     CheckUserResponseDTO findUserByNickname(CheckUserRequestDTO checkUserRequest);
     GetUserInfoResponseDTO getUserInfo(Long userId);

--- a/src/main/java/prefolio/prefolioserver/service/UserServiceImpl.java
+++ b/src/main/java/prefolio/prefolioserver/service/UserServiceImpl.java
@@ -1,6 +1,7 @@
 package prefolio.prefolioserver.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import org.springframework.transaction.annotation.Transactional;
@@ -11,14 +12,13 @@ import prefolio.prefolioserver.dto.response.GetUserInfoResponseDTO;
 import prefolio.prefolioserver.dto.response.CheckUserResponseDTO;
 import prefolio.prefolioserver.dto.response.JoinUserResponseDTO;
 import prefolio.prefolioserver.error.CustomException;
-import prefolio.prefolioserver.repository.UserRepository;
-import prefolio.prefolioserver.repository.ScrapRepository;
-import prefolio.prefolioserver.repository.LikeRepository;
+import prefolio.prefolioserver.service.repository.UserRepository;
+import prefolio.prefolioserver.service.repository.ScrapRepository;
+import prefolio.prefolioserver.service.repository.LikeRepository;
 
 import java.util.Date;
 import java.util.Optional;
 
-import static java.lang.Boolean.TRUE;
 import static java.lang.Boolean.valueOf;
 import static prefolio.prefolioserver.error.ErrorCode.USER_NOT_FOUND;
 
@@ -33,16 +33,15 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public JoinUserResponseDTO joinUser(JoinUserRequestDTO joinUserRequest) {
-        User user = User.builder()
-                .type(joinUserRequest.getType())
-                .nickname(joinUserRequest.getNickname())
-                .profileImage(joinUserRequest.getProfileImage())
-                .grade(joinUserRequest.getGrade())
-                .refreshToken(joinUserRequest.getRefreshToken())
-                .createdAt(new Date())
-                .build();
-        User savedUser = userRepository.saveAndFlush(user);
+    public JoinUserResponseDTO joinUser(UserDetailsImpl authUser, JoinUserRequestDTO joinUserRequest) {
+        User findUser = userRepository.findByEmail(authUser.getUsername())
+                .orElseThrow(() -> new UsernameNotFoundException("해당 유저를 찾을 수 없습니다."));
+        findUser.setType(joinUserRequest.getType());
+        findUser.setNickname(joinUserRequest.getNickname());
+        findUser.setProfileImage(joinUserRequest.getProfileImage());
+        findUser.setGrade(joinUserRequest.getGrade());
+        findUser.setCreatedAt(new Date());
+        User savedUser = userRepository.saveAndFlush(findUser);
         return new JoinUserResponseDTO(savedUser);
     }
 

--- a/src/main/java/prefolio/prefolioserver/service/repository/LikeRepository.java
+++ b/src/main/java/prefolio/prefolioserver/service/repository/LikeRepository.java
@@ -1,4 +1,4 @@
-package prefolio.prefolioserver.repository;
+package prefolio.prefolioserver.service.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import prefolio.prefolioserver.domain.Like;

--- a/src/main/java/prefolio/prefolioserver/service/repository/PostRepository.java
+++ b/src/main/java/prefolio/prefolioserver/service/repository/PostRepository.java
@@ -1,4 +1,4 @@
-package prefolio.prefolioserver.repository;
+package prefolio.prefolioserver.service.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import prefolio.prefolioserver.domain.Post;

--- a/src/main/java/prefolio/prefolioserver/service/repository/ScrapRepository.java
+++ b/src/main/java/prefolio/prefolioserver/service/repository/ScrapRepository.java
@@ -1,4 +1,4 @@
-package prefolio.prefolioserver.repository;
+package prefolio.prefolioserver.service.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import prefolio.prefolioserver.domain.Scrap;

--- a/src/main/java/prefolio/prefolioserver/service/repository/UserRepository.java
+++ b/src/main/java/prefolio/prefolioserver/service/repository/UserRepository.java
@@ -1,4 +1,4 @@
-package prefolio.prefolioserver.repository;
+package prefolio.prefolioserver.service.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import prefolio.prefolioserver.domain.User;


### PR DESCRIPTION
## 🚩 관련 이슈

- close #54 

## 📋 작업 내용

- [x] 회원가입용 DTO refreshtoken 필드 삭제
- [x] 회원가입시 새로운 객체 생성 대신 기존 유저의 정보 저장으로 변경

## 📌 PR Point

- 기존 로직에서는 카카오 로그인시 해당 유저의 객체가 생성되고 회원가입 로직을 실행했을 때 다시 새로운 정보가 생성됨
- 로그인한 유저의 정보를 회원가입 정보로 변경할 수 있도록 로직 구현

