### PR TITLE
Feat: 게시물 한 개 조회 API 구현

### DIFF
--- a/src/main/java/prefolio/prefolioserver/controller/PostController.java
+++ b/src/main/java/prefolio/prefolioserver/controller/PostController.java
@@ -99,16 +99,17 @@ public class PostController {
                     responseCode = "200",
                     description = "게시글 조회 성공",
                     content = @Content(
-                            schema = @Schema(implementation = CommonResponseDTO.class)
+                            schema = @Schema(implementation = GetPostResponseDTO.class)
                     )
             )
     })
-    @GetMapping("/{postId}")
+    @GetMapping("/post/{postId}")
     @ResponseBody
     public CommonResponseDTO<GetPostResponseDTO> getPost(
+            @AuthenticationPrincipal UserDetailsImpl authUser,
             @PathVariable(name = "postId") Long postId
     ) {
-        return CommonResponseDTO.onSuccess("게시글 조회 성공", postService.findPostById(postId));
+        return CommonResponseDTO.onSuccess("게시글 조회 성공", postService.findPostById(authUser, postId));
     }
 
     @Operation(

--- a/src/main/java/prefolio/prefolioserver/domain/Post.java
+++ b/src/main/java/prefolio/prefolioserver/domain/Post.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.Date;
+import java.util.List;
 
 @Entity
 @Getter
@@ -51,6 +52,12 @@ public class Post {
 
     @Column
     private Integer hits;
+
+    @OneToMany(mappedBy = "post")
+    private List<Like> likeList;
+
+    @OneToMany(mappedBy = "post")
+    private List<Scrap> scrapList;
 
     @Column(name = "created_at")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd hh:mm:ss", timezone = "Asia/Seoul")

--- a/src/main/java/prefolio/prefolioserver/dto/PostDTO.java
+++ b/src/main/java/prefolio/prefolioserver/dto/PostDTO.java
@@ -1,9 +1,11 @@
 package prefolio.prefolioserver.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import prefolio.prefolioserver.domain.Post;
 
 import java.util.Date;
@@ -14,7 +16,6 @@ import java.util.Date;
 @AllArgsConstructor
 public class PostDTO {
 
-    private Long id;
     private String thumbnail;
     private String title;
     private String startDate;
@@ -24,10 +25,10 @@ public class PostDTO {
     private String partTag;
     private String actTag;
     private Integer hits;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     private Date createdAt;
 
     public PostDTO(Post post) {
-        this.id = post.getId();
         this.thumbnail = post.getThumbnail();
         this.title = post.getTitle();
         this.startDate = post.getStartDate();

--- a/src/main/java/prefolio/prefolioserver/dto/UserDTO.java
+++ b/src/main/java/prefolio/prefolioserver/dto/UserDTO.java
@@ -1,0 +1,26 @@
+package prefolio.prefolioserver.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import prefolio.prefolioserver.domain.User;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserDTO {
+
+    private String type;
+    private String nickname;
+    private String profileImage;
+    private Integer grade;
+
+    public UserDTO(User user) {
+        this.type = user.getType();
+        this.nickname = user.getNickname();
+        this.profileImage = user.getProfileImage();
+        this.grade = user.getGrade();
+    }
+}

--- a/src/main/java/prefolio/prefolioserver/dto/response/GetPostResponseDTO.java
+++ b/src/main/java/prefolio/prefolioserver/dto/response/GetPostResponseDTO.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import prefolio.prefolioserver.domain.User;
 import prefolio.prefolioserver.dto.CountDTO;
 import prefolio.prefolioserver.dto.PostDTO;
+import prefolio.prefolioserver.dto.UserDTO;
 
 @Getter
 @Builder
@@ -14,11 +15,11 @@ public class GetPostResponseDTO {
 
     private PostDTO post;
     private CountDTO count;
-    private User user;
+    private UserDTO user;
     private Boolean isLiked;
     private Boolean isScrapped;
 
-    public GetPostResponseDTO(PostDTO post, CountDTO count, User user, Boolean isLiked, Boolean isScrapped) {
+    public GetPostResponseDTO(PostDTO post, CountDTO count, UserDTO user, Boolean isLiked, Boolean isScrapped) {
         this.post = post;
         this.count = count;
         this.user = user;

--- a/src/main/java/prefolio/prefolioserver/repository/LikeRepository.java
+++ b/src/main/java/prefolio/prefolioserver/repository/LikeRepository.java
@@ -1,4 +1,4 @@
-package prefolio.prefolioserver.service.repository;
+package prefolio.prefolioserver.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import prefolio.prefolioserver.domain.Like;

--- a/src/main/java/prefolio/prefolioserver/repository/PostRepository.java
+++ b/src/main/java/prefolio/prefolioserver/repository/PostRepository.java
@@ -1,4 +1,4 @@
-package prefolio.prefolioserver.service.repository;
+package prefolio.prefolioserver.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import prefolio.prefolioserver.domain.Post;

--- a/src/main/java/prefolio/prefolioserver/repository/ScrapRepository.java
+++ b/src/main/java/prefolio/prefolioserver/repository/ScrapRepository.java
@@ -1,4 +1,4 @@
-package prefolio.prefolioserver.service.repository;
+package prefolio.prefolioserver.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import prefolio.prefolioserver.domain.Scrap;

--- a/src/main/java/prefolio/prefolioserver/repository/UserRepository.java
+++ b/src/main/java/prefolio/prefolioserver/repository/UserRepository.java
@@ -1,4 +1,4 @@
-package prefolio.prefolioserver.service.repository;
+package prefolio.prefolioserver.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import prefolio.prefolioserver.domain.User;

--- a/src/main/java/prefolio/prefolioserver/service/KakaoServiceImpl.java
+++ b/src/main/java/prefolio/prefolioserver/service/KakaoServiceImpl.java
@@ -23,7 +23,7 @@ import org.springframework.web.client.RestTemplate;
 import prefolio.prefolioserver.domain.User;
 import prefolio.prefolioserver.dto.response.KakaoLoginResponseDTO;
 import prefolio.prefolioserver.dto.KakaoUserInfoDTO;
-import prefolio.prefolioserver.service.repository.UserRepository;
+import prefolio.prefolioserver.repository.UserRepository;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;

--- a/src/main/java/prefolio/prefolioserver/service/PostService.java
+++ b/src/main/java/prefolio/prefolioserver/service/PostService.java
@@ -12,7 +12,7 @@ public interface PostService {
 
     public AddPostResponseDTO savePost(UserDetailsImpl authUser, AddPostRequestDTO addPostDTO);
 
-    public GetPostResponseDTO findPostById(Long postId);
+    public GetPostResponseDTO findPostById(UserDetailsImpl authUser, Long postId);
 
     public ClickLikeResponseDTO clickLike(UserDetailsImpl authUser, Long postId, Boolean isLiked);
 

--- a/src/main/java/prefolio/prefolioserver/service/UserDetailsServiceImpl.java
+++ b/src/main/java/prefolio/prefolioserver/service/UserDetailsServiceImpl.java
@@ -6,7 +6,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import prefolio.prefolioserver.domain.User;
-import prefolio.prefolioserver.service.repository.UserRepository;
+import prefolio.prefolioserver.repository.UserRepository;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/prefolio/prefolioserver/service/UserServiceImpl.java
+++ b/src/main/java/prefolio/prefolioserver/service/UserServiceImpl.java
@@ -12,9 +12,9 @@ import prefolio.prefolioserver.dto.response.GetUserInfoResponseDTO;
 import prefolio.prefolioserver.dto.response.CheckUserResponseDTO;
 import prefolio.prefolioserver.dto.response.JoinUserResponseDTO;
 import prefolio.prefolioserver.error.CustomException;
-import prefolio.prefolioserver.service.repository.UserRepository;
-import prefolio.prefolioserver.service.repository.ScrapRepository;
-import prefolio.prefolioserver.service.repository.LikeRepository;
+import prefolio.prefolioserver.repository.UserRepository;
+import prefolio.prefolioserver.repository.ScrapRepository;
+import prefolio.prefolioserver.repository.LikeRepository;
 
 import java.util.Date;
 import java.util.Optional;


### PR DESCRIPTION
## 🚩 관련 이슈

- close #11

## 📋 작업 내용

- [x] GetPostDTO 생성
- [x] PostDTO 생성
- [x] CountDTO 생성
- [x] UserDTO 생성
- [x] 게시물 조회 API 구현


## 📌 PR Point

- 게시물 리턴 DTO중에 user정보만 유저 객체 자체를 리턴하는 과정에서 순환참조가 일어나서 무한로딩 상태에 마주쳤다.
- 이를 해결하기위해 annotation을 사용하거나 mapper를 사용하는 방법을 고민해보았다.
- 시간이 부족하여 mapper를 구현하기는 적합하지 않다 생각이 들어 userDTO를 생성해서 순환참조를 해결했다. 

