### PR TITLE
Feat: 메인피드 게시글 조회 구현

### DIFF
--- a/src/main/java/prefolio/prefolioserver/controller/PostController.java
+++ b/src/main/java/prefolio/prefolioserver/controller/PostController.java
@@ -8,12 +8,15 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import prefolio.prefolioserver.domain.Scrap;
+import prefolio.prefolioserver.domain.Post;
+import prefolio.prefolioserver.domain.constant.ActTag;
+import prefolio.prefolioserver.domain.constant.PartTag;
+import prefolio.prefolioserver.domain.constant.SortBy;
 import prefolio.prefolioserver.dto.*;
 import prefolio.prefolioserver.dto.request.AddPostRequestDTO;
-import prefolio.prefolioserver.dto.request.GetScrapRequestDTO;
 import prefolio.prefolioserver.dto.response.*;
 import prefolio.prefolioserver.service.PostService;
 import prefolio.prefolioserver.service.UserDetailsImpl;
@@ -43,8 +46,18 @@ public class PostController {
     })
     @GetMapping("/all")
     @ResponseBody
-    public String getAllPosts(HttpServletRequest request) {
-        return "getAllPosts";
+    public CommonResponseDTO<MainPostResponseDTO> getAllPosts(
+            @AuthenticationPrincipal UserDetailsImpl authUser,
+            @RequestParam(name = "sortBy") SortBy sortBy,
+            @RequestParam(name = "partTag", required = false) PartTag partTag,
+            @RequestParam(name = "actTag", required = false) ActTag actTag,
+            @RequestParam(name = "pageNum") Integer pageNum,
+            @RequestParam(name = "limit") Integer limit
+            ) {
+        return CommonResponseDTO.onSuccess(
+                "메인피드 게시물 조회 성공",
+                postService.getAllPosts(authUser, sortBy, partTag, actTag, pageNum, limit)
+        );
     }
 
     @Operation(

--- a/src/main/java/prefolio/prefolioserver/domain/Post.java
+++ b/src/main/java/prefolio/prefolioserver/domain/Post.java
@@ -7,12 +7,14 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.Date;
 import java.util.List;
 
 @Entity
 @Getter
+@Setter
 @Table(name = "Post")
 @NoArgsConstructor
 public class Post {
@@ -56,6 +58,12 @@ public class Post {
     @Column
     private Integer hits;
 
+    @Column
+    private Integer likes;
+
+    @Column
+    private Integer scraps;
+
     @OneToMany(mappedBy = "post")
     @JsonManagedReference
     private List<Like> likeList;
@@ -90,6 +98,8 @@ public class Post {
             String actTag,
             String contents,
             Integer hits,
+            Integer likes,
+            Integer scraps,
             Date createdAt,
             Date updatedAt,
             Date deletedAt
@@ -106,6 +116,8 @@ public class Post {
         this.actTag = actTag;
         this.contents = contents;
         this.hits = hits;
+        this.likes = likes;
+        this.scraps = scraps;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
         this.deletedAt = deletedAt;

--- a/src/main/java/prefolio/prefolioserver/domain/constant/ActTag.java
+++ b/src/main/java/prefolio/prefolioserver/domain/constant/ActTag.java
@@ -1,0 +1,17 @@
+package prefolio.prefolioserver.domain.constant;
+
+public enum ActTag {
+    SOCIETY("society"),
+    PROJECT("project"),
+    INTERN("intern");
+
+    private String actTag;
+
+    ActTag(String actTag) {
+        this.actTag = actTag;
+    }
+
+    public String getActTag() {
+        return this.actTag;
+    }
+}

--- a/src/main/java/prefolio/prefolioserver/domain/constant/PartTag.java
+++ b/src/main/java/prefolio/prefolioserver/domain/constant/PartTag.java
@@ -1,0 +1,17 @@
+package prefolio.prefolioserver.domain.constant;
+
+public enum PartTag {
+    PLAN("plan"),
+    DEV("dev"),
+    DESIGN("design");
+
+    private String partTag;
+
+    PartTag(String partTag) {
+        this.partTag = partTag;
+    }
+
+    public String getPartTag() {
+        return this.partTag;
+    }
+}

--- a/src/main/java/prefolio/prefolioserver/domain/constant/SortBy.java
+++ b/src/main/java/prefolio/prefolioserver/domain/constant/SortBy.java
@@ -1,0 +1,17 @@
+package prefolio.prefolioserver.domain.constant;
+
+public enum SortBy {
+    CREATED_AT("createdAt"),
+    LIKES("likes"),
+    HITS("hits");
+
+    private String sortBy;
+
+    SortBy(String sortBy) {
+        this.sortBy = sortBy;
+    }
+
+    public String getSortBy() {
+        return this.sortBy;
+    }
+}

--- a/src/main/java/prefolio/prefolioserver/dto/MainPostDTO.java
+++ b/src/main/java/prefolio/prefolioserver/dto/MainPostDTO.java
@@ -1,27 +1,33 @@
 package prefolio.prefolioserver.dto;
 
-import lombok.Getter;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.*;
 import prefolio.prefolioserver.domain.Post;
 
 import java.util.Date;
+import java.util.List;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class MainPostDTO {
 
     private Long id;
     private String thumbnail;
     private String title;
-    private String partTag;
-    private String actTag;
+    private List<String> partTag;
+    private List<String> actTag;
     private Integer hits;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     private Date createdAt;
 
-    public MainPostDTO(Post post) {
+    public MainPostDTO(Post post, List<String> partTag, List<String> actTag) {
         this.id = post.getId();
         this.thumbnail = post.getThumbnail();
         this.title = post.getTitle();
-        this.partTag = post.getPartTag();
-        this.actTag = post.getActTag();
+        this.partTag = partTag;
+        this.actTag = actTag;
         this.hits = post.getHits();
         this.createdAt = post.getCreatedAt();
     }

--- a/src/main/java/prefolio/prefolioserver/dto/response/MainPostResponseDTO.java
+++ b/src/main/java/prefolio/prefolioserver/dto/response/MainPostResponseDTO.java
@@ -1,0 +1,24 @@
+package prefolio.prefolioserver.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import prefolio.prefolioserver.dto.MainPostDTO;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+public class MainPostResponseDTO {
+
+    private List<MainPostDTO> posts;
+    private Integer totalPages;
+    private Long totalResults;
+
+    public MainPostResponseDTO(List<MainPostDTO> posts, Integer totalPages, Long totalResults) {
+        this.posts = posts;
+        this.totalPages = totalPages;
+        this.totalResults = totalResults;
+    }
+}

--- a/src/main/java/prefolio/prefolioserver/query/PostSpecification.java
+++ b/src/main/java/prefolio/prefolioserver/query/PostSpecification.java
@@ -1,0 +1,19 @@
+package prefolio.prefolioserver.query;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.springframework.data.jpa.domain.Specification;
+import prefolio.prefolioserver.domain.Post;
+
+public class PostSpecification {
+
+    public static Specification<Post> likePartTag(String partTag) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.like(root.get("partTag"), '%' + partTag + '%');
+    }
+
+    public static Specification<Post> likeActTag(String actTag) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.like(root.get("actTag"), '%' + actTag + '%');
+    }
+}

--- a/src/main/java/prefolio/prefolioserver/repository/PostRepository.java
+++ b/src/main/java/prefolio/prefolioserver/repository/PostRepository.java
@@ -1,8 +1,14 @@
 package prefolio.prefolioserver.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 import prefolio.prefolioserver.domain.Post;
+import prefolio.prefolioserver.dto.MainPostDTO;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
-
+public interface PostRepository extends JpaRepository<Post, Long>, JpaSpecificationExecutor<Post> {
+    Page<Post> findAll(Specification<Post> spec, Pageable pageable);
 }

--- a/src/main/java/prefolio/prefolioserver/service/PostService.java
+++ b/src/main/java/prefolio/prefolioserver/service/PostService.java
@@ -1,6 +1,11 @@
 package prefolio.prefolioserver.service;
 
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
+import prefolio.prefolioserver.domain.Post;
+import prefolio.prefolioserver.domain.constant.ActTag;
+import prefolio.prefolioserver.domain.constant.PartTag;
+import prefolio.prefolioserver.domain.constant.SortBy;
 import prefolio.prefolioserver.dto.request.AddPostRequestDTO;
 import prefolio.prefolioserver.dto.response.*;
 
@@ -8,6 +13,11 @@ import java.util.List;
 
 @Service
 public interface PostService {
+
+    public MainPostResponseDTO getAllPosts(
+            UserDetailsImpl authUser, SortBy sortBy, PartTag partTag,
+            ActTag actTag, Integer pageNum, Integer limit
+    );
 
     public AddPostResponseDTO savePost(UserDetailsImpl authUser, AddPostRequestDTO addPostDTO);
 


### PR DESCRIPTION
## 🚩 관련 이슈

- close #67

## 📋 작업 내용

- [x] 메인피드 게시글 조회 API 구현
- [x] partTag, actTag list 형식으로 리턴(DTO수정)
- [x] 리턴 용 DTO 생성
- [x] 쿼리 용 Enum 생성

## 📌 PR Point

- 다중 쿼리를 JpaSpecification을 사용하여 구현
- 응답 DTO에서 태그 파싱하여 리스트로 전달
- Page<>형식을 통해 페이지정보 확인

