### PR TITLE
[fix] 토큰 관련 커스텀 에러 적용 오류 해결 #98

### DIFF
--- a/src/main/java/prefolio/prefolioserver/config/WebSecurityConfig.java
+++ b/src/main/java/prefolio/prefolioserver/config/WebSecurityConfig.java
@@ -31,7 +31,7 @@ public class WebSecurityConfig {
             "/swagger-resources/**",
             "/swagger-ui/**",
             "/api-docs/**",
-            "/webjars/**"
+            "/webjars/**",
     };
     // 인증 실패 또는 인증헤더가 전달받지 못했을 때 핸들러
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;

--- a/src/main/java/prefolio/prefolioserver/config/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/prefolio/prefolioserver/config/jwt/JwtAccessDeniedHandler.java
@@ -6,7 +6,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 import prefolio.prefolioserver.error.ErrorCode;
-import static prefolio.prefolioserver.error.ErrorResponse.setResponse;
+import prefolio.prefolioserver.error.ErrorResponse;
 
 import java.io.IOException;
 
@@ -22,5 +22,11 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
     ) throws IOException {
         ErrorCode errorCode = ErrorCode.FORBIDDEN_USER;
         setResponse(response, errorCode);
+    }
+
+    public void setResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.getWriter().print(ErrorResponse.jsonOf(errorCode));
     }
 }

--- a/src/main/java/prefolio/prefolioserver/config/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/prefolio/prefolioserver/config/jwt/JwtAuthenticationEntryPoint.java
@@ -6,11 +6,11 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 import prefolio.prefolioserver.error.ErrorCode;
+import prefolio.prefolioserver.error.ErrorResponse;
 
 import java.io.IOException;
 
 
-import static prefolio.prefolioserver.error.ErrorResponse.setResponse;
 
 /** 인증되지 않았을 경우(비로그인) AuthenticationEntryPoint 부분에서 AuthenticationException 발생시키면서
  * 비로그인 상태에서 인증 실패 시, AuthenticationEntryPoint로 핸들링되어 이곳에서 처리 */
@@ -28,29 +28,42 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         if(exception == null || exception.equals(ErrorCode.NO_TOKEN.getCode())) {
             setResponse(response, ErrorCode.NO_TOKEN);
         }
-        //잘못된 타입의 토큰인 경우
-        else if(exception.equals(ErrorCode.INVALID_AUTH_TOKEN.getCode())) {
-            setResponse(response, ErrorCode.INVALID_AUTH_TOKEN);
+        //유효하지 않은 토큰인 경우
+        else if(exception.equals(ErrorCode.INVALID_ACCESS_TOKEN.getCode())) {
+            setResponse(response, ErrorCode.INVALID_ACCESS_TOKEN);
         }
-        //DB에 정보가 없는 토큰을 사용했울 때
-        else if(exception.equals(ErrorCode.INVALID_USER_TOKEN.getCode())) {
-            setResponse(response, ErrorCode.INVALID_USER_TOKEN);
-        }
-        //잘못된 서명
-        else if(exception.equals(ErrorCode.INVALID_SIGNATURE.getCode())) {
-            setResponse(response, ErrorCode.INVALID_SIGNATURE);
-        }
-        //토큰 만료된 경우
-        else if(exception.equals(ErrorCode.EXPIRED_TOKEN.getCode())) {
-            setResponse(response, ErrorCode.EXPIRED_TOKEN);
-        }
-        //지원되지 않는 토큰인 경우
-        else if(exception.equals(ErrorCode.UNSUPPORTED_TOKEN.getCode())) {
-            setResponse(response, ErrorCode.UNSUPPORTED_TOKEN);
-        }
-        else {
-            setResponse(response, ErrorCode.FORBIDDEN_USER);
-        }
+//        //잘못된 타입의 토큰인 경우
+//        else if(exception.equals(ErrorCode.INVALID_AUTH_TOKEN.getCode())) {
+//            setResponse(response, ErrorCode.INVALID_AUTH_TOKEN);
+//        }
+//        //DB에 정보가 없는 토큰을 사용했울 때
+//        else if(exception.equals(ErrorCode.INVALID_USER_TOKEN.getCode())) {
+//            setResponse(response, ErrorCode.INVALID_USER_TOKEN);
+//        }
+//        //잘못된 서명
+//        else if(exception.equals(ErrorCode.INVALID_SIGNATURE.getCode())) {
+//            setResponse(response, ErrorCode.INVALID_SIGNATURE);
+//        }
+//        //토큰 만료된 경우
+//        else if(exception.equals(ErrorCode.EXPIRED_TOKEN.getCode())) {
+//            setResponse(response, ErrorCode.EXPIRED_TOKEN);
+//        }
+//        //지원되지 않는 토큰인 경우
+//        else if(exception.equals(ErrorCode.UNSUPPORTED_TOKEN.getCode())) {
+//            setResponse(response, ErrorCode.UNSUPPORTED_TOKEN);
+//        }
+//        else {
+//            setResponse(response, ErrorCode.FORBIDDEN_USER);
+//        }
+    }
+
+    /**
+     *  스프링 시큐리티 예외 커스텀 함수
+     */
+    public void setResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.getWriter().print(ErrorResponse.jsonOf(errorCode));
     }
 
 }

--- a/src/main/java/prefolio/prefolioserver/error/ErrorResponse.java
+++ b/src/main/java/prefolio/prefolioserver/error/ErrorResponse.java
@@ -40,10 +40,4 @@ public class ErrorResponse {
 
         return jsonObject;
     }
-
-    public static void setResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
-        response.setContentType("application/json;charset=UTF-8");
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        response.getWriter().print(ErrorResponse.jsonOf(errorCode));
-    }
 }


### PR DESCRIPTION
## 🚩 관련 이슈

- close #98

## 📋 작업 내용

- [x] 토큰 관련 커스텀 에러 적용 오류 해결
- [x] 토큰 검증 로직 수정
- [x] 토큰 에러 종류 2가지로 수정

## 📌 PR Point

- request의 exception에 따라 커스텀 에러를 내보내는 로직을 만들어두고 실제로 request에 exception attribute를 추가하지 않아 어떠한 메세지도 나오지 않고 500 에러가 뜨는 상황이었음
- 인증 실패 상황 2가지 요청에 각각 알맞은 "exception" attribute를 추가하여 해결

## 📸 스크린샷

<img width="348" alt="커스텀 에러 해결" src="https://user-images.githubusercontent.com/74910760/214529411-e8724bf9-3991-428b-a850-f97573b5f4b9.png">
