### PR TITLE
Refactor: validateToken에서 에러 정보 저장 

### DIFF
--- a/src/main/java/prefolio/prefolioserver/config/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/prefolio/prefolioserver/config/jwt/JwtAuthenticationEntryPoint.java
@@ -28,10 +28,10 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         if(exception.equals(ErrorCode.NO_TOKEN.getCode())) {
             setResponse(response, ErrorCode.NO_TOKEN);
         }
-        //유효하지 않은 토큰인 경우
-        else if(exception.equals(ErrorCode.INVALID_ACCESS_TOKEN.getCode())) {
-            setResponse(response, ErrorCode.INVALID_ACCESS_TOKEN);
-        }
+//        //유효하지 않은 토큰인 경우
+//        else if(exception.equals(ErrorCode.INVALID_ACCESS_TOKEN.getCode())) {
+//            setResponse(response, ErrorCode.INVALID_ACCESS_TOKEN);
+//        }
         //잘못된 서명
         else if(exception.equals(ErrorCode.INVALID_SIGNATURE.getCode())) {
             setResponse(response, ErrorCode.INVALID_SIGNATURE);

--- a/src/main/java/prefolio/prefolioserver/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/prefolio/prefolioserver/config/jwt/JwtAuthenticationFilter.java
@@ -36,15 +36,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     ) throws IOException, ServletException {
         String token = jwtTokenService.getToken(request);
         if (token == null) {
-            request.setAttribute("exception", ErrorCode.NO_TOKEN.getCode());
             filterChain.doFilter(request, response);
             return;
         }
         if (StringUtils.isNotBlank(token) && jwtTokenService.validateToken(request, token)) {
             Authentication authentication = jwtTokenService.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
-        } else {
-            request.setAttribute("exception", INVALID_ACCESS_TOKEN.getCode());
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/java/prefolio/prefolioserver/service/JwtTokenService.java
+++ b/src/main/java/prefolio/prefolioserver/service/JwtTokenService.java
@@ -55,6 +55,7 @@ public class JwtTokenService {
             request.setAttribute("exception", ErrorCode.UNSUPPORTED_TOKEN.getCode());
         } catch (IllegalArgumentException ex) {
             log.error("JWT 토큰이 비어있습니다");
+            request.setAttribute("exception", ErrorCode.NO_TOKEN.getCode());
         }
         return false;
     }


### PR DESCRIPTION
## 🚩 관련 이슈

- close #107

## 📋 작업 내용

- [x] 토큰 에러 정보 처리 위치 validateToken으로 이동


