### PR TITLE
Feat: 태그 다중 선택 기능 구현

### DIFF
--- a/src/main/java/prefolio/prefolioserver/controller/PostController.java
+++ b/src/main/java/prefolio/prefolioserver/controller/PostController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.servlet.http.Part;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -17,6 +18,8 @@ import prefolio.prefolioserver.dto.request.AddPostRequestDTO;
 import prefolio.prefolioserver.dto.response.*;
 import prefolio.prefolioserver.service.PostService;
 import prefolio.prefolioserver.service.UserDetailsImpl;
+
+import java.util.List;
 
 
 @RestController
@@ -43,16 +46,15 @@ public class PostController {
     @GetMapping("/all")
     @ResponseBody
     public CommonResponseDTO<MainPostResponseDTO> getAllPosts(
-            @AuthenticationPrincipal UserDetailsImpl authUser,
             @RequestParam(name = "sortBy") SortBy sortBy,
-            @RequestParam(name = "partTag", required = false) PartTag partTag,
-            @RequestParam(name = "actTag", required = false) ActTag actTag,
+            @RequestParam(name = "partTagList", required = false) String partTagList,
+            @RequestParam(name = "actTagList", required = false) String actTagList,
             @RequestParam(name = "pageNum") Integer pageNum,
             @RequestParam(name = "limit") Integer limit
             ) {
         return CommonResponseDTO.onSuccess(
                 "메인피드 게시물 조회 성공",
-                postService.getAllPosts(authUser, sortBy, partTag, actTag, pageNum, limit)
+                postService.getAllPosts(sortBy, partTagList, actTagList, pageNum, limit)
         );
     }
 
@@ -75,15 +77,15 @@ public class PostController {
     public CommonResponseDTO<MainPostResponseDTO> getSearchPosts(
             @AuthenticationPrincipal UserDetailsImpl authUser,
             @RequestParam(name = "sortBy") SortBy sortBy,
-            @RequestParam(name = "partTag", required = false) PartTag partTag,
-            @RequestParam(name = "actTag", required = false) ActTag actTag,
+            @RequestParam(name = "partTagList", required = false) String partTagList,
+            @RequestParam(name = "actTagList", required = false) String actTagList,
             @RequestParam(name = "pageNum") Integer pageNum,
             @RequestParam(name = "limit") Integer limit,
             @RequestParam(name = "searchWord") String searchWord
     ) {
         return CommonResponseDTO.onSuccess(
                 "검색 결과 게시물 조회 성공",
-                postService.getSearchPosts(authUser, sortBy, partTag, actTag, pageNum, limit, searchWord));
+                postService.getSearchPosts(authUser, sortBy, partTagList, actTagList, pageNum, limit, searchWord));
     }
 
     @Operation(
@@ -196,11 +198,11 @@ public class PostController {
     @ResponseBody
     public CommonResponseDTO<CardPostResponseDTO> findPostByUserId(
             @PathVariable(name = "userId") Long userId,
-            @RequestParam(name = "partTag", required = false) PartTag partTag,
-            @RequestParam(name = "actTag", required = false) ActTag actTag,
+            @RequestParam(name = "partTagList", required = false) String partTagList,
+            @RequestParam(name = "actTagList", required = false) String actTagList,
             @RequestParam(name = "pageNum") Integer pageNum,
             @RequestParam(name = "limit") Integer limit) {
-        return CommonResponseDTO.onSuccess("SUCCESS", postService.findPostByUserId(userId, partTag, actTag, pageNum, limit));
+        return CommonResponseDTO.onSuccess("SUCCESS", postService.findPostByUserId(userId, partTagList, actTagList, pageNum, limit));
     }
 
     @Operation(
@@ -221,8 +223,8 @@ public class PostController {
     @ResponseBody
     public CommonResponseDTO<CardPostResponseDTO> findScrapByUserId(
             @AuthenticationPrincipal UserDetailsImpl authUser,
-            @RequestParam(name = "partTag", required = false) PartTag partTag,
-            @RequestParam(name = "actTag", required = false) ActTag actTag,
+            @RequestParam(name = "partTagList", required = false) PartTag partTag,
+            @RequestParam(name = "actTagList", required = false) ActTag actTag,
             @RequestParam(name = "pageNum") Integer pageNum,
             @RequestParam(name = "limit") Integer limit) {
         return CommonResponseDTO.onSuccess("SUCCESS", postService.findMyScrap(authUser, partTag, actTag, pageNum, limit));

--- a/src/main/java/prefolio/prefolioserver/query/PostSpecification.java
+++ b/src/main/java/prefolio/prefolioserver/query/PostSpecification.java
@@ -1,17 +1,38 @@
 package prefolio.prefolioserver.query;
 
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
 import org.springframework.data.jpa.domain.Specification;
 import prefolio.prefolioserver.domain.Post;
 import prefolio.prefolioserver.domain.User;
+import prefolio.prefolioserver.domain.constant.ActTag;
+import prefolio.prefolioserver.domain.constant.PartTag;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class PostSpecification {
 
-    public static Specification<Post> likePartTag(String partTag) {
-        return (root, query, criteriaBuilder) -> criteriaBuilder.like(root.get("partTag"), '%' + partTag + '%');
+    public static Specification<Post> likePartTag(List<String> partTagList) {
+        return ((root, query, criteriaBuilder) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            for (String partTag : partTagList) {
+                predicates.add(criteriaBuilder.like(root.get("partTag"), '%' + partTag + '%'));
+            }
+            return criteriaBuilder.or(predicates.toArray(predicates.toArray(new Predicate[0])));
+        });
     }
 
-    public static Specification<Post> likeActTag(String actTag) {
-        return (root, query, criteriaBuilder) -> criteriaBuilder.like(root.get("actTag"), '%' + actTag + '%');
+    public static Specification<Post> likeActTag(List<String> actTagList) {
+        return ((root, query, criteriaBuilder) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            for (String actTag : actTagList) {
+                predicates.add(criteriaBuilder.like(root.get("actTag"), '%' + actTag + '%'));
+            }
+            return criteriaBuilder.or(predicates.toArray(predicates.toArray(new Predicate[0])));
+        });
     }
 
     public static Specification<Post> likeTitle(String searchWord) {

--- a/src/main/java/prefolio/prefolioserver/service/PostService.java
+++ b/src/main/java/prefolio/prefolioserver/service/PostService.java
@@ -31,11 +31,9 @@ public class PostService{
 
 
     public MainPostResponseDTO getAllPosts(
-            UserDetailsImpl authUser, SortBy sortBy, PartTag partTag,
-            ActTag actTag, Integer pageNum, Integer limit
+            SortBy sortBy, String partTagList,
+            String actTagList, Integer pageNum, Integer limit
     ) {
-        User user = userRepository.findByEmail(authUser.getUsername())
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
         // 페이지 요청 정보
         PageRequest pageRequest = PageRequest.of(pageNum, limit, Sort.by(sortBy.getSortBy()).descending());
@@ -43,12 +41,12 @@ public class PostService{
         // 쿼리
         Specification<Post> spec = (root, query, criteriaBuilder) -> null;
 
-        if (partTag != null)  // 쿼리에 partTag 들어왔을 때
-            spec = spec.and(PostSpecification.likePartTag(partTag.getPartTag()));
+        if (partTagList != null)  // 쿼리에 partTag 들어왔을 때
+            spec = spec.and(PostSpecification.likePartTag(parseTag(partTagList)));
 //        else if (partTag == null)  // 쿼리에 partTag 없으면 로그인 유저 part 정보로 쿼리
 //            spec = spec.and(PostSpecification.likePartTag(user.getType()));
-        if (actTag != null)
-            spec = spec.and(PostSpecification.likeActTag(actTag.getActTag()));
+        if (actTagList != null)
+            spec = spec.and(PostSpecification.likeActTag(parseTag(actTagList)));
 
         Page<Post> findPosts = postRepository.findAll(spec, pageRequest);
         List<MainPostDTO> mainPostsList = new ArrayList<>();
@@ -64,8 +62,8 @@ public class PostService{
 
 
     public MainPostResponseDTO getSearchPosts(
-            UserDetailsImpl authUser, SortBy sortBy, PartTag partTag,
-            ActTag actTag, Integer pageNum, Integer limit, String searchWord
+            UserDetailsImpl authUser, SortBy sortBy, String partTagList,
+            String actTagList, Integer pageNum, Integer limit, String searchWord
     ) {
         User user = userRepository.findByEmail(authUser.getUsername())
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
@@ -76,12 +74,12 @@ public class PostService{
         // 쿼리
         Specification<Post> spec = PostSpecification.likeTitle(searchWord)  // 검색
                 .or(PostSpecification.likeContents(searchWord));
-        if (partTag != null)  // 쿼리에 partTag 들어왔을 때
-            spec = spec.and(PostSpecification.likePartTag(partTag.getPartTag()));
+        if (partTagList != null)  // 쿼리에 partTag 들어왔을 때
+            spec = spec.and(PostSpecification.likePartTag(parseTag(partTagList)));
 //        else if (partTag == null)  // 쿼리에 partTag 없으면 로그인 유저 part 정보로 쿼리
 //            spec = spec.and(PostSpecification.likePartTag(user.getType()));
-        if (actTag != null)
-            spec = spec.and(PostSpecification.likeActTag(actTag.getActTag()));
+        if (actTagList != null)
+            spec = spec.and(PostSpecification.likeActTag(parseTag(actTagList)));
 
         Page<Post> findPosts = postRepository.findAll(spec, pageRequest);
         List<MainPostDTO> mainPostsList = new ArrayList<>();
@@ -248,7 +246,7 @@ public class PostService{
 
 
     public CardPostResponseDTO findPostByUserId(
-            Long userId, PartTag partTag, ActTag actTag, Integer pageNum, Integer limit) {
+            Long userId, String partTagList, String actTagList, Integer pageNum, Integer limit) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
@@ -256,11 +254,11 @@ public class PostService{
 
         Specification<Post> spec = (root, query, criteriaBuilder) -> null;
 
-        if (partTag!=null){
-            spec = spec.and(PostSpecification.likePartTag(partTag.getPartTag()));
+        if (partTagList!=null){
+            spec = spec.and(PostSpecification.likePartTag(parseTag(partTagList)));
         }
-        if (actTag!=null){
-            spec = spec.and(PostSpecification.likeActTag(actTag.getActTag()));
+        if (actTagList!=null){
+            spec = spec.and(PostSpecification.likeActTag(parseTag(actTagList)));
         }
         spec = spec.and(PostSpecification.equalUser(user));
         Page<Post> findPosts = postRepository.findAll(spec, pageRequest);


### PR DESCRIPTION
## 🚩 관련 이슈

- close #126

## 📋 작업 내용

- [x] 태그 필요한 API 모두 수정(메인피드, 검색, 유저게시글)

## 📌 PR Point

- 태그 하나 선택에서 다중 선택으로 로직 변경

